### PR TITLE
Update gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx512m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
A better option would be to use Xmx512m instead of Xmx1536m as there is a error due to that option.
Error:Unable to start the daemon process. This problem might be caused by incorrect configuration of the daemon. For example, an unrecognized jvm option is used. Please refer to the user guide chapter on the daemon at https://docs.gradle.org/4.4/userguide/gradle_daemon.html Please read the following process output to find out more: ----------------------- Error occurred during initialization of VM Could not reserve enough space for 1572864KB object heap

Cause; The error is due to low level memory problem and also 32bit environment problem where is not possible to allocate so much memory for the heap

Closes #
 -
 
### What changes are introduced to solve this?
 -use Xmx512m instead of Xmx1536m and thus lower memory allocation
      
### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No

### Pull Request Type
What kind of change does this Pull Request introduce?
 - [x]  Bugfix
 - [ ]  Feature
 - [ ]  Code style update
 - [ ]  Refactoring
 - [ ]  Documentation content changes
 - [ ]  Other… Please describe:

### How to Test the Code?
 - Describe: On a 32-bit PC , one may try to rebuild the project. there is no error

### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
	
Other Information :
 - I am a newbie and thus if i believe i did not follow the best practices so please suggest any changes
